### PR TITLE
New audio bus editor ui menu

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -658,6 +658,9 @@ void EditorNode::_notification(int p_what) {
 
 			ResourceImporterTexture::get_singleton()->update_imports();
 
+			// Update audio bus button colors
+			_update_bus_button_colors();
+
 			if (requested_first_scan) {
 				requested_first_scan = false;
 
@@ -762,6 +765,11 @@ void EditorNode::_notification(int p_what) {
 			// Set up a theme context for the 2D preview viewport using the stored preview theme.
 			CanvasItemEditor::ThemePreviewMode theme_preview_mode = (CanvasItemEditor::ThemePreviewMode)(int)EditorSettings::get_singleton()->get_project_metadata("2d_editor", "theme_preview", CanvasItemEditor::THEME_PREVIEW_PROJECT);
 			update_preview_themes(theme_preview_mode);
+
+			// Initialize audio bus buttons and connect to layout changes
+			AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorNode::_rebuild_bus_buttons));
+			AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &EditorNode::_on_bus_renamed));
+			_rebuild_bus_buttons();
 
 			/* DO NOT LOAD SCENES HERE, WAIT FOR FILE SCANNING AND REIMPORT TO COMPLETE */
 		} break;
@@ -6699,6 +6707,93 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 	return eta.exitcode;
 }
 
+void EditorNode::_rebuild_bus_buttons() {
+	// Clear existing buttons
+	for (KeyValue<int, Button *> &kv : audio_bus_buttons) {
+		audio_bus_buttons_hb->remove_child(kv.value);
+		memdelete(kv.value);
+	}
+	audio_bus_buttons.clear();
+
+	// Create buttons for each bus
+	int bus_count = AudioServer::get_singleton()->get_bus_count();
+	for (int i = 0; i < bus_count; i++) {
+		Button *bus_button = memnew(Button);
+		bus_button->set_flat(false);
+		if ((String)AudioServer::get_singleton()->get_bus_name(i) == "Master") {
+			bus_button->set_icon(theme->get_icon(SNAME("AudioStreamPlayer"), EditorStringName(EditorIcons)));
+		} else {
+			bus_button->set_text(AudioServer::get_singleton()->get_bus_name(i));
+		}
+
+		bus_button->set_tooltip_text(TTR("Toggle mute for bus: ") + AudioServer::get_singleton()->get_bus_name(i));
+		bus_button->connect("pressed", callable_mp(this, &EditorNode::_on_bus_button_pressed).bind(i));
+		audio_bus_buttons_hb->add_child(bus_button);
+		audio_bus_buttons[i] = bus_button;
+	}
+
+	// Update colors for the new buttons
+	_update_bus_button_colors();
+}
+
+void EditorNode::_update_bus_button_colors() {
+	for (KeyValue<int, Button *> &kv : audio_bus_buttons) {
+		int bus_index = kv.key;
+		Button *button = kv.value;
+
+		if (bus_index < AudioServer::get_singleton()->get_bus_count()) {
+			bool is_muted = AudioServer::get_singleton()->is_bus_mute(bus_index);
+			Color color;
+			if (is_muted) {
+				// Red for muted, slightly different for master and non-master buses
+				if ((String)AudioServer::get_singleton()->get_bus_name(bus_index) == "Master") {
+					color = Color(0.94, 0.44, 0.56, 1.0); // Red for muted
+				} else {
+					color = Color(0.85, 0.28, 0.44, 0.85); // Red for muted, opacity at 0.85 for non-master buses
+				}
+			} else {
+				// Green for not muted, slightly different for master and non-master buses
+				if ((String)AudioServer::get_singleton()->get_bus_name(bus_index) == "Master") {
+					color = Color(0.46, 0.85, 0.69, 1.0); // Green for not muted
+				} else {
+					color = Color(0.36, 0.73, 0.58, 0.85); // Green for not muted, opacity at 0.85 for non-master buses
+				}
+			}
+			button->add_theme_color_override("font_color", color);
+			button->add_theme_color_override("icon_normal_color", color);
+			button->add_theme_color_override("icon_pressed_color", color);
+			button->add_theme_color_override("icon_hover_color", color);
+			button->add_theme_color_override("icon_focus_color", color);
+		}
+	}
+}
+
+void EditorNode::_on_bus_button_pressed(int p_bus_index) {
+	if (p_bus_index < AudioServer::get_singleton()->get_bus_count()) {
+		bool current_mute = AudioServer::get_singleton()->is_bus_mute(p_bus_index);
+		bool new_mute = !current_mute;
+
+		EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+		ur->create_action(TTR("Toggle Audio Bus Mute"));
+		ur->add_do_method(AudioServer::get_singleton(), "set_bus_mute", p_bus_index, new_mute);
+		ur->add_undo_method(AudioServer::get_singleton(), "set_bus_mute", p_bus_index, current_mute);
+		if (audio_bus_editor) {
+			ur->add_do_method(audio_bus_editor, "_update_bus", p_bus_index);
+			ur->add_undo_method(audio_bus_editor, "_update_bus", p_bus_index);
+		}
+		ur->commit_action();
+	}
+}
+
+void EditorNode::_on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name) {
+	// Update button text when a bus is renamed
+	if (audio_bus_buttons.has(p_bus_index)) {
+		Button *button = audio_bus_buttons[p_bus_index];
+		button->set_text(p_new_name);
+		button->set_tooltip_text(TTR("Toggle mute for bus: ") + p_new_name);
+	}
+}
+
 EditorNode::EditorNode() {
 	DEV_ASSERT(!singleton);
 	singleton = this;
@@ -7167,7 +7262,7 @@ EditorNode::EditorNode() {
 		editor_logo_quick_menu->get_popup()->add_item(TTR("Search Help"), HELP_SEARCH);
 		editor_logo_quick_menu->get_popup()->add_item(TTR("Online Documentation"), HELP_DOCS);
 		editor_logo_quick_menu->get_popup()->add_item(TTR("Tekisasu Developer Resources"), HELP_DEVSITE);
-		editor_logo_quick_menu->get_popup()->add_item(TTR("Export Project"), FILE_EXPORT_PROJECT);	
+		editor_logo_quick_menu->get_popup()->add_item(TTR("Export Project"), FILE_EXPORT_PROJECT);
 		editor_logo_quick_menu->get_popup()->add_item(TTR("Manage Export Templates"), SETTINGS_MANAGE_EXPORT_TEMPLATES);
 		editor_logo_quick_menu->get_popup()->add_separator();
 		editor_logo_quick_menu->get_popup()->add_item(TTR("Quit to Project Manager"), RUN_PROJECT_MANAGER);
@@ -7357,6 +7452,16 @@ EditorNode::EditorNode() {
 	main_editor_button_hb = memnew(HBoxContainer);
 	title_bar->add_child(main_editor_button_hb);
 
+	// Audio bus toggle buttons container
+	// Spacer to center 2D / 3D / Script buttons.
+	HBoxContainer *audio_bus_spacer = memnew(HBoxContainer);
+	audio_bus_spacer->set_mouse_filter(Control::MOUSE_FILTER_PASS);
+	audio_bus_spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	title_bar->add_child(audio_bus_spacer);
+	audio_bus_buttons_hb = memnew(HBoxContainer);
+	audio_bus_buttons_hb->set_alignment(BoxContainer::ALIGNMENT_CENTER);
+	title_bar->add_child(audio_bus_buttons_hb);
+
 	// Options are added and handled by DebuggerEditorPlugin.
 	debug_menu = memnew(PopupMenu);
 	debug_menu->set_name(TTR("Debug"));
@@ -7435,7 +7540,6 @@ EditorNode::EditorNode() {
 		// On macOS  "Quit" and "About" options are in the "app" menu.
 		help_menu->add_icon_shortcut(theme->get_icon(SNAME("Tekisasu"), EditorStringName(EditorIcons)), ED_SHORTCUT_AND_COMMAND("editor/about", TTR("About")), HELP_ABOUT);
 	}
-
 
 	// Spacer to center 2D / 3D / Script buttons.
 	Control *right_spacer = memnew(Control);
@@ -7729,7 +7833,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(Node3DEditorPlugin));
 	add_editor_plugin(memnew(ScriptEditorPlugin));
 
-	EditorAudioBuses *audio_bus_editor = EditorAudioBuses::register_editor();
+	audio_bus_editor = EditorAudioBuses::register_editor();
 
 	ScriptTextEditor::register_editor(); // Register one for text scripts.
 	TextEditor::register_editor();

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -80,6 +80,7 @@ class DependencyErrorDialog;
 class DockSplitContainer;
 class DynamicFontImportSettingsDialog;
 class EditorAbout;
+class EditorAudioBuses;
 class EditorBuildProfileManager;
 class EditorBottomPanel;
 class EditorCommandPalette;
@@ -297,6 +298,7 @@ private:
 	EditorResourcePreview *resource_preview = nullptr;
 	EditorSelection *editor_selection = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;
+	EditorAudioBuses *audio_bus_editor = nullptr;
 	HistoryDock *history_dock = nullptr;
 
 	ProjectExportDialog *project_export = nullptr;
@@ -433,6 +435,9 @@ private:
 	HBoxContainer *main_editor_button_hb = nullptr;
 	Vector<Button *> main_editor_buttons;
 	Vector<EditorPlugin *> editor_table;
+
+	HBoxContainer *audio_bus_buttons_hb = nullptr;
+	HashMap<int, Button *> audio_bus_buttons;
 
 	AudioStreamPreviewGenerator *audio_preview_gen = nullptr;
 	ProgressDialog *progress_dialog = nullptr;
@@ -700,6 +705,11 @@ private:
 	void _notify_nodes_scene_reimported(Node *p_node, Array p_reimported_nodes);
 
 	void _remove_all_not_owned_children(Node *p_node, Node *p_owner);
+
+	void _rebuild_bus_buttons();
+	void _update_bus_button_colors();
+	void _on_bus_button_pressed(int p_bus_index);
+	void _on_bus_renamed(int p_bus_index, const StringName &p_old_name, const StringName &p_new_name);
 
 protected:
 	friend class FileSystemDock;


### PR DESCRIPTION
This PR adds a new Editor UI widget to the main menubar between the 2d/3d/script and runbar sections.  The speaker icon is used to denote the Master audio channel.  All other audio buses are represented by buttons.  Each one can be toggled off easily without entering the Audio mixer and stored entirely in the project settings rather than handle dev mode settings in the project's gdscript game code.  Green is unmuted, red is muted.